### PR TITLE
Fix id of user from int to string

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -2,7 +2,7 @@ package messengerbot
 
 import "github.com/satori/go.uuid"
 
-func NewUserFromId(id int64) User {
+func NewUserFromId(id string) User {
 	return User{
 		Id: id,
 	}

--- a/send.go
+++ b/send.go
@@ -40,7 +40,7 @@ var (
 )
 
 type User struct {
-	Id          int64  `json:"id,omitempty"`
+	Id          string  `json:"id,omitempty"`
 	PhoneNumber string `json:"phone_number,omitempty"`
 }
 
@@ -186,7 +186,7 @@ type SendRequest struct {
 }
 
 type SendResponse struct {
-	RecipientId int64         `json:"recipient_id"`
+	RecipientId string         `json:"recipient_id"`
 	MessageId   string        `json:"message_id"`
 	Error       ErrorResponse `json:"error"`
 }

--- a/webhook.go
+++ b/webhook.go
@@ -15,7 +15,7 @@ type rawEvent struct {
 }
 
 type Event struct {
-	Id   int64 `json:"id"`
+	Id   string `json:"id"`
 	Time int64 `json:"time"`
 }
 
@@ -52,11 +52,11 @@ type Optin struct {
 
 type MessageOpts struct {
 	Sender struct {
-		ID int64 `json:"id"`
+		ID string `json:"id"`
 	} `json:"sender"`
 
 	Recipient struct {
-		ID int64 `json:"id"`
+		ID string `json:"id"`
 	} `json:"recipient"`
 
 	Timestamp int64 `json:"timestamp"`


### PR DESCRIPTION
- Reviewed current developer.facebook.com, write official user-id in string.
- App can't build or push to GAE really when the type is int.
