### PR TITLE
Add channel for event-handlers

### DIFF
--- a/messengerbot.go
+++ b/messengerbot.go
@@ -11,6 +11,7 @@ type MessengerBot struct {
 	MessageDelivered MessageDeliveredHandler
 	Postback         PostbackHandler
 	Authentication   AuthenticationHandler
+	Error				     ErrorHandler
 
 	VerifyToken string
 	AppSecret   string // Optional: For validating integrity of messages

--- a/messengerbot.go
+++ b/messengerbot.go
@@ -11,7 +11,7 @@ type MessengerBot struct {
 	MessageDelivered MessageDeliveredHandler
 	Postback         PostbackHandler
 	Authentication   AuthenticationHandler
-	Error				     ErrorHandler
+	Error            ErrorHandler
 
 	VerifyToken string
 	AppSecret   string // Optional: For validating integrity of messages

--- a/send.go
+++ b/send.go
@@ -40,7 +40,7 @@ var (
 )
 
 type User struct {
-	Id          string  `json:"id,omitempty"`
+	Id          string `json:"id,omitempty"`
 	PhoneNumber string `json:"phone_number,omitempty"`
 }
 
@@ -186,7 +186,7 @@ type SendRequest struct {
 }
 
 type SendResponse struct {
-	RecipientId string         `json:"recipient_id"`
+	RecipientId string        `json:"recipient_id"`
 	MessageId   string        `json:"message_id"`
 	Error       ErrorResponse `json:"error"`
 }

--- a/webhook.go
+++ b/webhook.go
@@ -16,7 +16,7 @@ type rawEvent struct {
 
 type Event struct {
 	Id   string `json:"id"`
-	Time int64 `json:"time"`
+	Time int64  `json:"time"`
 }
 
 type MessageEvent struct {


### PR DESCRIPTION
Thanks for merge last pull-req.

I add channels on go-routines for some reasons.

```
Current "handler"s are all event-handlers delegated by go-routine, that's nice. However,
it doesn't work for some long-time jobs like a network call on webservver(i.e GAE).
Add boolean channel to construct cocurrency for such jobs.

The channel is boolean for success or failed status inside go-routine.
```

Think about it, it might be useful.
